### PR TITLE
Add elixir paths config by environament

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,7 @@ defmodule GenReport.MixProject do
   def project do
     [
       app: :gen_report,
+      elixirc_paths: elixirc_paths(Mix.env()),
       version: "0.1.0",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
@@ -17,6 +18,10 @@ defmodule GenReport.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do


### PR DESCRIPTION
## Problem

The test was failed because can't find  `GenReport.Support.ReportFixture.build/0 ` :

```
  1) test build/1 When passing file name return a report (GenReportTest)
     test/gen_report_test.exs:10
     ** (UndefinedFunctionError) function GenReport.Support.ReportFixture.build/0 is undefined (module GenReport.Support.ReportFixture is not available)
     code: assert response == ReportFixture.build()
     stacktrace:
       GenReport.Support.ReportFixture.build()
       test/gen_report_test.exs:13: (test)
```

## Solution

Adds `elixirc_paths` config to `mix.exs`  based on the environament